### PR TITLE
Remove openssl requirement.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,8 @@ hunter_add_package(enet)
 find_package(enet CONFIG REQUIRED)
 hunter_add_package(yaml-cpp)
 find_package(yaml-cpp CONFIG REQUIRED)
-hunter_add_package(OpenSSL)
-find_package(OpenSSL REQUIRED)
+#hunter_add_package(OpenSSL)
+#find_package(OpenSSL REQUIRED)
 hunter_add_package(PNG)
 find_package(PNG CONFIG REQUIRED)
 
@@ -422,8 +422,8 @@ target_link_libraries(vorb
     glm
     enet::enet
     yaml-cpp::yaml-cpp
-    OpenSSL::SSL
-    OpenSSL::Crypto
+#    OpenSSL::SSL
+#    OpenSSL::Crypto
     Lua::lua_lib
     PNG::png
 )

--- a/include/Vorb/io/File.h
+++ b/include/Vorb/io/File.h
@@ -46,17 +46,17 @@ namespace vorb {
         };
         ENUM_CLASS_OPS_INL(FileOpenFlags, ui8)
 
-        // TODO: Maybe move sum elsewhere?
-        struct SHA256Sum {
-            const ui32& operator[](const size_t& i) const {
-                return m_data[i];
-            }
-            ui32& operator[](const size_t& i) {
-                return m_data[i];
-            }
-        private:
-            ui32 m_data[8];
-        };
+//        // TODO: Maybe move sum elsewhere?
+//        struct SHA256Sum {
+//            const ui32& operator[](const size_t& i) const {
+//                return m_data[i];
+//            }
+//            ui32& operator[](const size_t& i) {
+//                return m_data[i];
+//            }
+//        private:
+//            ui32 m_data[8];
+//        };
 
         /// Represents a file
         class File {
@@ -75,8 +75,8 @@ namespace vorb {
             bool isValid() const {
                 return m_path.isValid();
             }
-            /// @return A file checksum
-            void computeSum(OUT SHA256Sum* sum) const;
+//            /// @return A file checksum
+//            void computeSum(OUT SHA256Sum* sum) const;
 
             /// @return The size of the file in bytes
             ui64 length() const;

--- a/src/io/File.cpp
+++ b/src/io/File.cpp
@@ -3,7 +3,7 @@
 
 #include <boost/filesystem/operations.hpp>
 //#include <sha256/sha256sum.h>
-#include <openssl/sha.h>
+//#include <openssl/sha.h>
 
 #include "Vorb/io/FileOps.h"
 #include "Vorb/io/FileStream.h"
@@ -35,28 +35,28 @@ bool vorb::io::File::resize(const ui64& l) const {
     return ec.value() == 0;
 }
 
-void vorb::io::File::computeSum(vio::SHA256Sum* sum) const {
-    vio::FileSeekOffset l = 0;
-    ui8* data = nullptr;
-
-    { // Read file data
-        vio::FileStream s = openReadOnly(true);
-        l = s.length();
-        data = new ui8[l];
-        l = (vio::FileSeekOffset)s.read(l, 1, data);
-        s.close();
-    }
-
-    { // Compute sum
-        SHA256_CTX context;
-        SHA256_Init(&context);
-        SHA256_Update(&context, data, (ui32)l);
-        SHA256_Final((unsigned char *)sum, &context);
-//        memcpy(sum, context.hash, 32);
-    }
-
-    delete[] data;
-}
+//void vorb::io::File::computeSum(vio::SHA256Sum* sum) const {
+//    vio::FileSeekOffset l = 0;
+//    ui8* data = nullptr;
+//
+//    { // Read file data
+//        vio::FileStream s = openReadOnly(true);
+//        l = s.length();
+//        data = new ui8[l];
+//        l = (vio::FileSeekOffset)s.read(l, 1, data);
+//        s.close();
+//    }
+//
+//    { // Compute sum
+//        SHA256_CTX context;
+//        SHA256_Init(&context);
+//        SHA256_Update(&context, data, (ui32)l);
+//        SHA256_Final((unsigned char *)sum, &context);
+////        memcpy(sum, context.hash, 32);
+//    }
+//
+//    delete[] data;
+//}
 
 vio::FileStream vio::File::open(FileOpenFlags flags) const {
     FileStream stream(*this);


### PR DESCRIPTION
Remove openssl requirement as it requires perl to be installed and it is currently not used.